### PR TITLE
Fixed ESRI maps not exporting

### DIFF
--- a/server.py
+++ b/server.py
@@ -275,8 +275,12 @@ def pred_tile():
         current_data_loader = DATALOADERS[dataset]
 
     try:
-        input_raster = current_data_loader.get_data_from_geometry(geom["geometry"])
         shape_area = get_area_from_geometry(geom["geometry"])
+
+        if shape_area > 10:
+            raise ValueError("Dataset area is too big")
+
+        input_raster = current_data_loader.get_data_from_geometry(geom["geometry"])
     except NotImplementedError as e: # Example of how to handle errors from the rest of the server
         bottle.response.status = 400
         return json.dumps({"error": "Cannot currently download imagery with 'Basemap' based datasets"})


### PR DESCRIPTION
This PR fixes #24

Hi, as mentioned in the issue `get_data_from_geometry` was unimplemented so I implemented it based on the `get_data_from_extent` function and added an area restriction. Although I'm not sure if this would be best in the `get_data_from_geometry` function so it won't affect other DataLoaders and if 10km^2 is about the right max size.